### PR TITLE
fix: add loading in use-media-query

### DIFF
--- a/src/hooks/use-media-query.ts
+++ b/src/hooks/use-media-query.ts
@@ -10,7 +10,8 @@ const mobileBreakpoint = `(max-width: ${tailwindConfig.theme.screens.xl || '768p
  *
  * @param query - A string representing the media query to evaluate. Defaults to the mobile breakpoint defined in Tailwind CSS config, or '(max-width: 768px)' if not provided.
  * @returns An object containing:
- *   - matches: A boolean indicating whether the media query currently matches.
+ *   - value: A boolean indicating whether the media query currently matches.
+ *   - loading: A boolean indicating whether the media query evaluation is still in progress.
  *
  * This hook leverages the `matchMedia` API to evaluate media queries in the browser. It sets up an event listener
  * to respond to changes in the media query's evaluation status and ensures the component re-renders with the updated
@@ -20,42 +21,45 @@ const mobileBreakpoint = `(max-width: ${tailwindConfig.theme.screens.xl || '768p
  * - Default media query: If no query is provided, the hook defaults to the mobile breakpoint from Tailwind CSS config.
  * - Dynamic evaluation: Re-evaluates the media query whenever the input query string changes.
  * - Cleanup: Properly removes the event listener when the component is unmounted or the query changes.
+ * - Initial state: Correctly initializes the state based on the current media query match status.
  *
  * Example usage:
  *
- * const { matches: isMobile } = useMediaQuery('(max-width: 600px)');
+ * const { loading, value: isMobile} = useMediaQuery('(max-width: 600px)');
  *
  * return (
  *   <div>
- *     <p>{isMobile ? 'Mobile View' : 'Desktop View'}</p>
+ *     {loading ? <p>Loading...</p> : <p>{isMobile ? 'Mobile View' : 'Desktop View'}</p>}
  *   </div>
  * );
  *
  * Example with default query:
  *
- * const { matches: isDefault } = useMediaQuery();
+ * const { loading, value: isDefault } = useMediaQuery();
  *
  * return (
  *   <div>
- *     <p>{isDefault ? 'Desktop View' : 'Mobile View'}</p>
+ *     {loading ? <p>Loading...</p> : <p>{isDefault ? 'Mobile View' : 'Desktop View'}</p>}
  *   </div>
  * );
  */
+
 export default function useMediaQuery(query: string = mobileBreakpoint) {
-  const [matches, setMatches] = useState(() => matchMedia(query).matches);
+  const [value, setValue] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    const mediaQueryList = matchMedia(query);
-
     function onChange(event: MediaQueryListEvent) {
-      setMatches(event.matches);
+      setValue(event.matches);
     }
 
-    mediaQueryList.addEventListener('change', onChange);
-    setMatches(mediaQueryList.matches);
+    const result = matchMedia(query);
+    result.addEventListener('change', onChange);
+    setValue(result.matches);
+    setLoading(false);
 
-    return () => mediaQueryList.removeEventListener('change', onChange);
+    return () => result.removeEventListener('change', onChange);
   }, [query]);
 
-  return { matches };
+  return { loading, value };
 }


### PR DESCRIPTION
## Description

The original version may cause rendering issues on Next.js. Fix it by implementing a loading state. Developers may need to manually control the loading state to prevent flashing issues.