### PR TITLE
refactor: 💡call to action section - convert px to rem

### DIFF
--- a/src/components/CallToActionSection/CallToActionSection.tsx
+++ b/src/components/CallToActionSection/CallToActionSection.tsx
@@ -30,7 +30,7 @@ const CallToActionSection = ({ className }: CalltoActionSectionProps) => {
           讓你來揪咖！
         </h1>
         <div className="w-fit bg-surface px-4 py-8">
-          <Separator className="h-[0.125rem] w-12 bg-primary" />
+          <Separator className="h-0.5 w-12 bg-primary" />
         </div>
         <Small className="w-fit bg-surface p-4 pb-0 leading-6">
           Your Crew, Your Call

--- a/src/components/CallToActionSection/CallToActionSection.tsx
+++ b/src/components/CallToActionSection/CallToActionSection.tsx
@@ -14,23 +14,23 @@ const CallToActionSection = ({ className }: CalltoActionSectionProps) => {
   return (
     <section
       className={cn(
-        'relative pb-[100px] pt-[72px] text-primary xl:max-w-[81rem] xl:pb-0 xl:pt-20',
+        'relative pb-[6.25rem] pt-[4.5rem] text-primary xl:max-w-[81rem] xl:pb-0 xl:pt-20',
         className
       )}
     >
       <div className="absolute left-0 top-0">
-        <H1 className="w-fit bg-surface pl-[13px] pr-4 xl:pb-4">
+        <H1 className="w-fit bg-surface pl-[0.8125rem] pr-4 xl:pb-4">
           找不到
           <br className="hidden xl:block" />
           心目中的
           <br className="xl:hidden" />
           活動嗎？
         </H1>
-        <h1 className="bg-surface pb-4 pl-[13px] pr-4 text-5xl font-bold -tracking-[0.012em] xl:-mt-3 xl:w-fit">
+        <h1 className="bg-surface pb-4 pl-[0.8125rem] pr-4 text-5xl font-bold -tracking-[0.012em] xl:-mt-3 xl:w-fit">
           讓你來揪咖！
         </h1>
         <div className="w-fit bg-surface px-4 py-8">
-          <Separator className="h-[2px] w-12 bg-primary" />
+          <Separator className="h-[0.125rem] w-12 bg-primary" />
         </div>
         <Small className="w-fit bg-surface p-4 pb-0 leading-6">
           Your Crew, Your Call
@@ -39,15 +39,15 @@ const CallToActionSection = ({ className }: CalltoActionSectionProps) => {
           Bring Your Own Adventure!
         </Small>
       </div>
-      <Video className="h-[750px] w-full xl:h-[420px] xl:px-[110px]" />
-      <div className="absolute bottom-0 right-0 pb-[33px] pl-[31px] pr-[30px] pt-[34px]">
+      <Video className="h-[46.875rem] w-full xl:h-[26.25rem] xl:px-[6.875rem]" />
+      <div className="absolute bottom-0 right-0 pb-[2.0625rem] pl-[1.9375rem] pr-[1.875rem] pt-[2.125rem]">
         <Button className="relative h-full bg-transparent p-0 text-base font-medium text-surface transition duration-300 ease-out hover:bg-transparent hover:text-primary">
           <div className="absolute left-0 top-0 ">
             <CallToActionButtonBackground />
           </div>
           <Link
             href="/activity"
-            className="z-10 px-[38px] py-[55px] text-primary hover:text-surface"
+            className="z-10 px-[2.375rem] py-[3.4375rem] text-primary hover:text-surface"
           >
             開始揪咖
           </Link>


### PR DESCRIPTION
## Problem
The Call to Action section was using `px` units for sizing, which is inconsistent with the team's coding style that prefers `rem` units.

## Description
Convert `px` units to `rem` units in the Call to Action section to conform to the team's coding style.

## Approach
1. Identified all `px` units in the Call to Action section.
2. Converted these `px` units to `rem` units.