### PR TITLE
feat: 🎸 forgot and reset password

### DIFF
--- a/src/action/auth.ts
+++ b/src/action/auth.ts
@@ -35,7 +35,7 @@ export async function login(
 
       return {
         status: 'failed',
-        message: `${errorMessage ?? 'Login failed'} (${response.status})`,
+        message: `${errorMessage ?? '登入失敗，請稍後重新再試。'} (${response.status})`,
       };
     }
 
@@ -44,7 +44,7 @@ export async function login(
 
     return {
       status: 'success',
-      message: 'Successfully logged in',
+      message: '登入成功，歡迎回到 chillka！',
     };
   } catch (error) {
     return {
@@ -69,15 +69,16 @@ export async function register(
 
     if (!response.ok) {
       const errorMessage = await response.text();
+
       return {
         status: 'failed',
-        message: `${errorMessage ?? 'Register failed'} (${response.status})`,
+        message: `${errorMessage ?? '註冊失敗，請稍後重新再試。'} (${response.status})`,
       };
     }
 
     return {
       status: 'success',
-      message: 'success register',
+      message: '註冊成功，歡迎加入 chillka！',
     };
   } catch (error) {
     return {
@@ -125,7 +126,7 @@ export async function forgotPassword(
 
       return {
         status: 'failed',
-        message: `${errorMessage ?? '發送重設密碼信件失敗，請重新再試。'} (${response.status})`,
+        message: `${errorMessage ?? '發送重設密碼信件失敗，請稍後重新再試。'} (${response.status})`,
       };
     }
 
@@ -163,7 +164,7 @@ export async function resetPassword(
 
       return {
         status: 'failed',
-        message: `${errorMessage ?? '重設密碼失敗，請重新再試。'} (${response.status})`,
+        message: `${errorMessage ?? '重設密碼失敗，請稍後重新再試。'} (${response.status})`,
       };
     }
 

--- a/src/app/auth/forgot-password/page.tsx
+++ b/src/app/auth/forgot-password/page.tsx
@@ -1,5 +1,20 @@
-const Page = () => {
-  return <div>忘記密碼</div>;
+import { Card, CardContent, CardHeader } from '@components/ui/card';
+import { H3 } from '@components/ui/typography';
+import ForgotPasswordForm from '@components/user/ForgotPasswordForm';
+
+const ForgotPasswordPage = () => {
+  return (
+    <section>
+      <Card className="bg-surface">
+        <CardHeader className="text-center">
+          <H3 className="text-primary">忘記密碼</H3>
+        </CardHeader>
+        <CardContent>
+          <ForgotPasswordForm />
+        </CardContent>
+      </Card>
+    </section>
+  );
 };
 
-export default Page;
+export default ForgotPasswordPage;

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -5,7 +5,7 @@ const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div
       className={cn(
-        'mt-6 flex min-h-[calc(100vh-var(--header-height)-var(--footer-height))] w-full justify-center xl:mt-20'
+        'flex min-h-[calc(100vh-var(--header-height)-var(--footer-height))] w-full justify-center px-3 pb-24 pt-9 xl:px-0 xl:pb-28 xl:pt-20'
       )}
     >
       <div className="w-[23rem]">{children}</div>

--- a/src/app/auth/reset-password/page.tsx
+++ b/src/app/auth/reset-password/page.tsx
@@ -1,0 +1,20 @@
+import { Card, CardContent, CardHeader } from '@components/ui/card';
+import { H3 } from '@components/ui/typography';
+import ResetPasswordForm from '@components/user/ResetPasswordForm';
+
+const ResetPasswordPage = () => {
+  return (
+    <section>
+      <Card className="bg-surface">
+        <CardHeader className="text-center">
+          <H3 className="text-primary">重設密碼</H3>
+        </CardHeader>
+        <CardContent>
+          <ResetPasswordForm />
+        </CardContent>
+      </Card>
+    </section>
+  );
+};
+
+export default ResetPasswordPage;

--- a/src/components/user/ForgotPasswordForm/ForgotPasswordForm.tsx
+++ b/src/components/user/ForgotPasswordForm/ForgotPasswordForm.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { Button } from '@components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@components/ui/form';
+import { Input } from '@components/ui/input';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { forgotPasswordFormSchema } from '@lib/definitions';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+const ForgotPasswordForm = () => {
+  const form = useForm<z.output<typeof forgotPasswordFormSchema>>({
+    resolver: zodResolver(forgotPasswordFormSchema),
+    defaultValues: {
+      email: '',
+    },
+  });
+
+  const handleSubmit = () => {
+    console.log('test');
+  };
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={handleSubmit}
+        className="flex w-full flex-col space-y-4 text-primary"
+      >
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>信箱</FormLabel>
+              <FormControl>
+                <Input
+                  className="bg-white placeholder:text-base placeholder:text-[#8F8A88]"
+                  placeholder="請輸入信箱"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit">送出</Button>
+      </form>
+    </Form>
+  );
+};
+
+export default ForgotPasswordForm;

--- a/src/components/user/ForgotPasswordForm/ForgotPasswordForm.tsx
+++ b/src/components/user/ForgotPasswordForm/ForgotPasswordForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { forgotPassword } from '@action/auth';
 import { Button } from '@components/ui/button';
 import {
   Form,
@@ -10,12 +11,16 @@ import {
   FormMessage,
 } from '@components/ui/form';
 import { Input } from '@components/ui/input';
+import { toast } from '@components/ui/use-toast';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { forgotPasswordFormSchema } from '@lib/definitions';
+import { useTransition } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 const ForgotPasswordForm = () => {
+  const [isPending, startTransition] = useTransition();
+
   const form = useForm<z.output<typeof forgotPasswordFormSchema>>({
     resolver: zodResolver(forgotPasswordFormSchema),
     defaultValues: {
@@ -23,9 +28,17 @@ const ForgotPasswordForm = () => {
     },
   });
 
-  const handleSubmit = () => {
-    console.log('test');
-  };
+  const handleSubmit = form.handleSubmit(async (data) => {
+    startTransition(async () => {
+      const result = await forgotPassword(data);
+      if (result?.message !== '') {
+        toast({
+          title: result?.message ?? 'Unknown error',
+          variant: result?.status === 'success' ? 'default' : 'destructive',
+        });
+      }
+    });
+  });
 
   return (
     <Form {...form}>
@@ -50,7 +63,9 @@ const ForgotPasswordForm = () => {
             </FormItem>
           )}
         />
-        <Button type="submit">送出</Button>
+        <Button type="submit" disabled={isPending}>
+          送出
+        </Button>
       </form>
     </Form>
   );

--- a/src/components/user/ForgotPasswordForm/ForgotPasswordForm.tsx
+++ b/src/components/user/ForgotPasswordForm/ForgotPasswordForm.tsx
@@ -13,6 +13,7 @@ import {
 import { Input } from '@components/ui/input';
 import { toast } from '@components/ui/use-toast';
 import { zodResolver } from '@hookform/resolvers/zod';
+import useCooldown from '@hooks/use-cool-down';
 import { forgotPasswordFormSchema } from '@lib/definitions';
 import { useTransition } from 'react';
 import { useForm } from 'react-hook-form';
@@ -20,6 +21,10 @@ import { z } from 'zod';
 
 const ForgotPasswordForm = () => {
   const [isPending, startTransition] = useTransition();
+  const { cooldownSeconds, startCooldown } = useCooldown(
+    'forgotPasswordCooldown',
+    0
+  );
 
   const form = useForm<z.output<typeof forgotPasswordFormSchema>>({
     resolver: zodResolver(forgotPasswordFormSchema),
@@ -37,6 +42,7 @@ const ForgotPasswordForm = () => {
           variant: result?.status === 'success' ? 'default' : 'destructive',
         });
       }
+      if (result?.status === 'success') startCooldown(60);
     });
   });
 
@@ -63,8 +69,8 @@ const ForgotPasswordForm = () => {
             </FormItem>
           )}
         />
-        <Button type="submit" disabled={isPending}>
-          送出
+        <Button type="submit" disabled={isPending || cooldownSeconds > 0}>
+          {cooldownSeconds > 0 ? `請稍候 ${cooldownSeconds} 秒再送出` : '送出'}
         </Button>
       </form>
     </Form>

--- a/src/components/user/ForgotPasswordForm/index.ts
+++ b/src/components/user/ForgotPasswordForm/index.ts
@@ -1,0 +1,3 @@
+import ForgotPasswordForm from './ForgotPasswordForm';
+
+export default ForgotPasswordForm;

--- a/src/components/user/ResetPasswordForm/ResetPasswordForm.tsx
+++ b/src/components/user/ResetPasswordForm/ResetPasswordForm.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { resetPassword } from '@action/auth';
+import { Button } from '@components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@components/ui/form';
+import { Input } from '@components/ui/input';
+import { toast } from '@components/ui/use-toast';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { resetPasswordFormSchema } from '@lib/definitions';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useTransition } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+const ResetPasswordForm = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const validateCode = searchParams.get('validateCode');
+  const [isPending, startTransition] = useTransition();
+
+  const form = useForm<z.output<typeof resetPasswordFormSchema>>({
+    resolver: zodResolver(resetPasswordFormSchema),
+    defaultValues: {
+      password: '',
+      confirmPassword: '',
+    },
+  });
+
+  const handleSubmit = form.handleSubmit(async (data) => {
+    startTransition(async () => {
+      const result = await resetPassword(validateCode as string, data);
+      if (result?.message !== '') {
+        toast({
+          title: result?.message ?? 'Unknown error',
+          variant: result?.status === 'success' ? 'default' : 'destructive',
+        });
+      }
+      if (result?.status === 'success') router.push('/auth/login');
+    });
+  });
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={handleSubmit}
+        className="flex w-full flex-col space-y-4 text-primary"
+      >
+        <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>密碼</FormLabel>
+              <FormControl>
+                <Input
+                  className="bg-white placeholder:text-base placeholder:text-[#8F8A88]"
+                  type="password"
+                  placeholder="請輸入密碼"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="confirmPassword"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>確認密碼</FormLabel>
+              <FormControl>
+                <Input
+                  className="bg-white placeholder:text-base placeholder:text-[#8F8A88]"
+                  type="password"
+                  placeholder="請輸入密碼"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" disabled={isPending}>
+          送出
+        </Button>
+      </form>
+    </Form>
+  );
+};
+
+export default ResetPasswordForm;

--- a/src/components/user/ResetPasswordForm/index.ts
+++ b/src/components/user/ResetPasswordForm/index.ts
@@ -1,0 +1,3 @@
+import ResetPasswordForm from './ResetPasswordForm';
+
+export default ResetPasswordForm;

--- a/src/hooks/use-cool-down.ts
+++ b/src/hooks/use-cool-down.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * A custom hook that manages a cooldown timer. The cooldown state is saved in localStorage,
+ * allowing the timer to persist across page reloads.
+ *
+ * @param {number} initialCooldown - The initial cooldown period in seconds.
+ * @param {string} storageKey - The key under which the cooldown timer is stored in localStorage.
+ * @returns {Object} An object containing the current cooldown seconds and a function to start the cooldown.
+ * @returns {number} cooldownSeconds - The current number of seconds remaining in the cooldown.
+ * @returns {function} startCooldown - A function to start the cooldown with a specified number of seconds.
+ *
+ * @example
+ * const { cooldownSeconds, startCooldown } = useCooldown(0, 'forgotPasswordCooldown');
+ * startCooldown(300); // Start a cooldown of 300 seconds
+ */
+
+const useCooldown = (storageKey: string, initialCooldown: number = 0) => {
+  const [cooldownSeconds, setCooldownSeconds] = useState(() => {
+    const savedCooldown = localStorage.getItem(storageKey);
+    return savedCooldown ? parseInt(savedCooldown, 10) : initialCooldown;
+  });
+
+  useEffect(() => {
+    if (cooldownSeconds > 0) {
+      const timer = setInterval(() => {
+        setCooldownSeconds((prevCooldownSeconds) => {
+          const newCooldownSeconds = prevCooldownSeconds - 1;
+          localStorage.setItem(storageKey, newCooldownSeconds.toString());
+          return newCooldownSeconds;
+        });
+      }, 1000);
+      return () => clearInterval(timer);
+    }
+    localStorage.removeItem(storageKey);
+    return () => {};
+  }, [cooldownSeconds, storageKey]);
+
+  const startCooldown = (seconds: number) => {
+    setCooldownSeconds(seconds);
+    localStorage.setItem(storageKey, seconds.toString());
+  };
+
+  return { cooldownSeconds, startCooldown };
+};
+
+export default useCooldown;

--- a/src/lib/definitions.ts
+++ b/src/lib/definitions.ts
@@ -14,18 +14,18 @@ export type FormState =
 export const loginFormSchema = z.object({
   email: z
     .string()
-    .min(1, { message: 'This field has to be filled.' })
-    .max(50)
-    .email(),
+    .min(1, { message: '此欄位為必填' })
+    .max(50, { message: '不得超過50個字元' })
+    .email({ message: '請輸入有效的電子郵件地址' }),
   password: z.string().min(8).max(50),
 });
 
 export const registerFormSchema = z.object({
   email: z
     .string()
-    .min(1, { message: 'This field has to be filled.' })
-    .max(50)
-    .email(),
+    .min(1, { message: '此欄位為必填' })
+    .max(50, { message: '不得超過50個字元' })
+    .email({ message: '請輸入有效的電子郵件地址' }),
   password: z.string().min(8).max(50),
   confirmPassword: z.string().min(8).max(50),
   displayName: z.string().min(1).max(50),
@@ -34,14 +34,14 @@ export const registerFormSchema = z.object({
 export const forgotPasswordFormSchema = z.object({
   email: z
     .string()
-    .min(1, { message: 'This field has to be filled.' })
-    .max(50)
-    .email(),
+    .min(1, { message: '此欄位為必填' })
+    .max(50, { message: '不得超過50個字元' })
+    .email({ message: '請輸入有效的電子郵件地址' }),
 });
 
 export const userFormSchema = z.object({
   displayName: z
     .string()
-    .min(2, { message: 'The min is 2' })
-    .max(50, { message: 'The max is 2' }),
+    .min(2, { message: '最少需要2個字元' })
+    .max(50, { message: '最多不得超過50個字元' }),
 });

--- a/src/lib/definitions.ts
+++ b/src/lib/definitions.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod';
 
 export const endpoint = process.env.API_ENDPOINT;
+export const REQUIRED_FIELD_MESSAGE = '此欄位為必填';
+export const MAX_LENGTH_MESSAGE = (length: number) =>
+  `最多不得超過${length}個字元`;
+export const MIN_LENGTH_MESSAGE = (length: number) => `最少需要${length}個字元`;
+export const VALID_EMAIL_MESSAGE = '請輸入有效的電子郵件地址';
 
 export type FormState =
   | {
@@ -14,39 +19,57 @@ export type FormState =
 export const loginFormSchema = z.object({
   email: z
     .string()
-    .min(1, { message: '此欄位為必填' })
-    .max(50, { message: '不得超過50個字元' })
-    .email({ message: '請輸入有效的電子郵件地址' }),
-  password: z.string().min(8).max(50),
+    .min(1, { message: REQUIRED_FIELD_MESSAGE })
+    .max(50, { message: MAX_LENGTH_MESSAGE(50) })
+    .email({ message: VALID_EMAIL_MESSAGE }),
+  password: z
+    .string()
+    .min(8, { message: MIN_LENGTH_MESSAGE(8) })
+    .max(50, { message: MAX_LENGTH_MESSAGE(50) }),
 });
 
 export const registerFormSchema = z.object({
   email: z
     .string()
-    .min(1, { message: '此欄位為必填' })
-    .max(50, { message: '不得超過50個字元' })
-    .email({ message: '請輸入有效的電子郵件地址' }),
-  password: z.string().min(8).max(50),
-  confirmPassword: z.string().min(8).max(50),
-  displayName: z.string().min(1).max(50),
+    .min(1, { message: REQUIRED_FIELD_MESSAGE })
+    .max(50, { message: MAX_LENGTH_MESSAGE(50) })
+    .email({ message: VALID_EMAIL_MESSAGE }),
+  password: z
+    .string()
+    .min(8, { message: MIN_LENGTH_MESSAGE(8) })
+    .max(50, { message: MAX_LENGTH_MESSAGE(50) }),
+  confirmPassword: z
+    .string()
+    .min(8, { message: MIN_LENGTH_MESSAGE(8) })
+    .max(50, { message: MAX_LENGTH_MESSAGE(50) }),
+  displayName: z
+    .string()
+    .min(2, { message: MIN_LENGTH_MESSAGE(2) })
+    .max(50, { message: MAX_LENGTH_MESSAGE(50) }),
 });
 
 export const forgotPasswordFormSchema = z.object({
   email: z
     .string()
-    .min(1, { message: '此欄位為必填' })
-    .max(50, { message: '不得超過50個字元' })
-    .email({ message: '請輸入有效的電子郵件地址' }),
+    .min(1, { message: REQUIRED_FIELD_MESSAGE })
+    .max(50, { message: MAX_LENGTH_MESSAGE(50) })
+    .email({ message: VALID_EMAIL_MESSAGE }),
 });
 
 export const resetPasswordFormSchema = z.object({
-  password: z.string().min(8).max(50),
-  confirmPassword: z.string().min(8).max(50),
+  password: z
+    .string()
+    .min(8, { message: MIN_LENGTH_MESSAGE(8) })
+    .max(50, { message: MAX_LENGTH_MESSAGE(50) }),
+  confirmPassword: z
+    .string()
+    .min(8, { message: MIN_LENGTH_MESSAGE(8) })
+    .max(50, { message: MAX_LENGTH_MESSAGE(50) }),
 });
 
 export const userFormSchema = z.object({
   displayName: z
     .string()
-    .min(2, { message: '最少需要2個字元' })
-    .max(50, { message: '最多不得超過50個字元' }),
+    .min(2, { message: MIN_LENGTH_MESSAGE(2) })
+    .max(50, { message: MAX_LENGTH_MESSAGE(50) }),
 });

--- a/src/lib/definitions.ts
+++ b/src/lib/definitions.ts
@@ -39,6 +39,11 @@ export const forgotPasswordFormSchema = z.object({
     .email({ message: '請輸入有效的電子郵件地址' }),
 });
 
+export const resetPasswordFormSchema = z.object({
+  password: z.string().min(8).max(50),
+  confirmPassword: z.string().min(8).max(50),
+});
+
 export const userFormSchema = z.object({
   displayName: z
     .string()

--- a/src/lib/definitions.ts
+++ b/src/lib/definitions.ts
@@ -31,6 +31,14 @@ export const registerFormSchema = z.object({
   displayName: z.string().min(1).max(50),
 });
 
+export const forgotPasswordFormSchema = z.object({
+  email: z
+    .string()
+    .min(1, { message: 'This field has to be filled.' })
+    .max(50)
+    .email(),
+});
+
 export const userFormSchema = z.object({
   displayName: z
     .string()


### PR DESCRIPTION
## Description
新增忘記密碼與重設密碼畫面與功能

## Expected Results
1. 在忘記密碼頁輸入信箱（必須是已註冊之信箱）時，信箱應收到重置密碼驗證信
2. 點擊重置密碼驗證信中的網址，會導向至重設密碼頁
3. 在重設密碼頁輸入密碼與確認密碼欄位後，成功將跳轉至登入頁
4. 使用者可以使用新的密碼登入

## Note
1. 忘記密碼新增 cooldown 機制，將秒數存取至 localStorage，必須1分鐘後才能重新發送驗證信
2. 調整表單欄位驗證的提示文字（fields）
3. 調整提交表單後的提示訊息（toast）
