### PR TITLE
feat: enhance the middleware route handle

### DIFF
--- a/src/action/utils.ts
+++ b/src/action/utils.ts
@@ -81,6 +81,18 @@ export const getJwtPayload = async () => {
   }
 };
 
+export const isTokenExpiredOrError = async (): Promise<boolean> => {
+  try {
+    const payload = await getJwtPayload();
+    if (!payload || !payload.exp) return true;
+
+    const currentTime = Math.floor(Date.now() / 1000);
+    return payload.exp < currentTime;
+  } catch (error) {
+    return true;
+  }
+};
+
 interface FetchOptions<T> {
   api: string;
   method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
@@ -89,7 +101,6 @@ interface FetchOptions<T> {
   shouldAuth?: boolean;
   option?: RequestInit;
 }
-
 /**
  * Executes an Next fetch.
  *


### PR DESCRIPTION
- 目前有兩個判斷函數`handleAuthRelatedPaths`和`handlePrivatePaths`
  - `handleAuthRelatedPaths`為原先方法抽取出來
  - `handlePrivatePaths`處理需要使用token的頁面，token過期或出錯會在下一個response進行跳轉