### PR TITLE
feat: 🎸 enhance styles for member center

### DIFF
--- a/src/app/member-center/manage-event/[id]/[name]/page.tsx
+++ b/src/app/member-center/manage-event/[id]/[name]/page.tsx
@@ -15,14 +15,11 @@ const ManageEventIdPage = async ({ params }: ManageEventIdPageProps) => {
 
   return (
     <div className="relative text-primary">
-      <div className="relative mb-6 h-[8.125rem] xl:flex xl:h-fit xl:items-center xl:justify-between">
-        <Link
-          href="/member-center/manage-event"
-          className="flex flex-row gap-2"
-        >
-          <ArrowLeftFromLine className="size-12" />
-          <h1 className="mb-8 text-5xl/none font-bold xl:mb-0">{decodeName}</h1>
+      <div className="relative mb-12 flex text-5xl/none font-bold">
+        <Link href="/member-center/manage-event" className="mr-4 mt-3 h-fit">
+          <ArrowLeftFromLine className="size-8" />
         </Link>
+        <h1>{decodeName}</h1>
       </div>
 
       <section className="flex flex-col gap-2">

--- a/src/app/member-center/manage-event/page.tsx
+++ b/src/app/member-center/manage-event/page.tsx
@@ -6,10 +6,10 @@ const ManageEventPage = async () => {
 
   return (
     <div className="relative text-primary">
-      <div className="relative mb-6 h-[8.125rem] xl:flex xl:h-fit xl:items-center xl:justify-between">
-        <h1 className="mb-8 text-5xl/none font-bold xl:mb-0">管理活動</h1>
-      </div>
-      <section className="flex flex-col gap-2">
+      <h1 className="mb-6 h-[5rem] border-b-[0.0625rem] text-5xl/none font-bold xl:h-[6.25rem]">
+        管理活動
+      </h1>
+      <section className="flex flex-col gap-4">
         {/* // FIXME: Change the proper type */}
         {activities.length > 0 &&
           activities.map((activity: any) => (

--- a/src/app/member-center/manage-event/utils/ManagementActivitySection.tsx
+++ b/src/app/member-center/manage-event/utils/ManagementActivitySection.tsx
@@ -32,10 +32,20 @@ const ManagementActivitySection = ({
 
   return (
     <Tabs defaultValue="table" className="w-full">
-      <div className="mb-6 flex w-full flex-col justify-between xl:flex-row">
-        <TabsList className="grid w-full grid-cols-2 xl:w-[50%]">
-          <TabsTrigger value="table">參加者名單</TabsTrigger>
-          <TabsTrigger value="report">報表</TabsTrigger>
+      <div className="mb-6 flex w-full max-w-full flex-col justify-between xl:flex-row">
+        <TabsList className="mb-4 grid max-w-full grid-cols-2 bg-primary text-white xl:mb-0 xl:w-[50%]">
+          <TabsTrigger
+            value="table"
+            className="data-[state=active]:text-primary"
+          >
+            參加者名單
+          </TabsTrigger>
+          <TabsTrigger
+            value="report"
+            className="data-[state=active]:text-primary"
+          >
+            報表
+          </TabsTrigger>
         </TabsList>
         <QRCodeScannerDialogButton
           onScanSuccess={handleScanSuccess}
@@ -46,7 +56,7 @@ const ManagementActivitySection = ({
         <TabsContent className="min-w-[37.5rem]" value="table" asChild>
           <ManagementActivityTable orders={orders} />
         </TabsContent>
-        <TabsContent className="min-w-[37.5rem]" value="report">
+        <TabsContent className="min-w-[37.5rem]" value="report" asChild>
           report
         </TabsContent>
       </div>

--- a/src/app/member-center/manage-event/utils/ManagementActivityTable.tsx
+++ b/src/app/member-center/manage-event/utils/ManagementActivityTable.tsx
@@ -37,8 +37,8 @@ const ManagementActivityTable = ({ orders }: ManagementActivityTableProps) => {
       <div className="mb-4 flex flex-col justify-between gap-2 xl:flex-row xl:gap-0">
         <Input
           variant="form"
-          placeholder="搜索名稱或電子郵件"
-          className="w-full xl:max-w-sm"
+          placeholder="搜尋名稱或電子郵件"
+          className="w-full focus-visible:ring-0 focus-visible:ring-offset-0 xl:w-[26rem]"
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
         />
@@ -50,13 +50,21 @@ const ManagementActivityTable = ({ orders }: ManagementActivityTableProps) => {
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead className="w-[50px]">
-              <SquareCheckBig className="size-4" />
+            <TableHead className="w-12">
+              <SquareCheckBig className="size-4 text-primary" />
             </TableHead>
-            <TableHead>參加者</TableHead>
-            <TableHead>帳號</TableHead>
-            <TableHead>年齡</TableHead>
-            <TableHead>狀態</TableHead>
+            <TableHead className="text-base font-bold text-primary">
+              參加者
+            </TableHead>
+            <TableHead className="text-base font-bold text-primary">
+              帳號
+            </TableHead>
+            <TableHead className="text-base font-bold text-primary">
+              年齡
+            </TableHead>
+            <TableHead className="text-base font-bold text-primary">
+              狀態
+            </TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/src/app/member-center/manage-event/utils/ManagementCard.tsx
+++ b/src/app/member-center/manage-event/utils/ManagementCard.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '@components/ui/button';
 import { Card } from '@components/ui/card';
+import { Lead } from '@components/ui/typography';
 import cn from '@lib/utils';
 import { format } from 'date-fns';
 import { SquareArrowOutUpRight } from 'lucide-react';
@@ -32,53 +33,64 @@ const ManagementCard = ({
   return (
     <Card
       className={cn(
-        'flex w-full gap-4',
-        'h-auto flex-col items-stretch rounded-none p-2',
-        'xl:h-32 xl:flex-row xl:items-center xl:rounded-r-2xl xl:py-0 xl:pl-0 xl:pr-2'
+        'flex w-full',
+        'h-auto flex-col items-stretch rounded-none',
+        'xl:h-60 xl:flex-row xl:items-center',
+        'bg-transparent text-primary'
       )}
     >
       <div
         className={cn(
           'relative flex-shrink-0 overflow-hidden ',
           'h-48 w-full',
-          'xl:h-full xl:w-32'
+          'xl:h-full xl:w-60'
         )}
       >
         <Image src={thumbnail} alt={name} fill objectFit="cover" />
       </div>
-      <div className="flex h-full flex-grow flex-col justify-between py-4">
-        <div className="w-fit bg-primary text-sm text-white">{category}</div>
-        <div
-          className={cn(
-            'grid gap-4 text-xs',
-            'grid-cols-2  grid-rows-4',
-            'xl:grid-cols-4 xl:grid-rows-2'
-          )}
-        >
+      <div className="flex h-full flex-grow flex-col justify-between p-4">
+        <div className="mb-4 w-fit bg-primary px-2 py-1 text-xs/5 font-medium text-white">
+          {category}
+        </div>
+        <div className={cn('grid gap-4 text-xs', 'grid-cols-3  grid-rows-4')}>
           <Link href={`/activity/${id}`} className="order-1">
-            <div className="flex flex-row items-center gap-2">
-              <div className="font-semibold">活動名稱</div>
-              <SquareArrowOutUpRight className="size-3" />
+            <div className="flex w-full flex-row items-center gap-2">
+              <Lead>活動名稱</Lead>
+              <SquareArrowOutUpRight className="size-4" />
             </div>
           </Link>
-          <div className="order-3 font-semibold xl:order-2">日期</div>
-          <div className="order-5 font-semibold xl:order-3">位置</div>
-          <div className="order-7 font-semibold xl:order-4">參加人數</div>
-          <div className="order-2 xl:order-5">{name}</div>
-          <div className="order-4 xl:order-6">
+          <Lead className="order-3">日期</Lead>
+          <Lead className="order-5">位置</Lead>
+          <Lead className="order-7">參加人數</Lead>
+          <Lead className="order-2 col-span-2 line-clamp-1 font-medium">
+            {name}
+          </Lead>
+          <Lead className="order-4 col-span-2 font-medium">
+            {' '}
             {format(startDateTime, 'yyyy-MM-dd')} -{' '}
             {format(endDateTime, 'yyyy-MM-dd')}
-          </div>
-          <div className="order-6 xl:order-7">{address}</div>
-          <div className="order-8 xl:order-8">{participantCount}</div>
+          </Lead>
+          <Lead className="order-6 col-span-2 line-clamp-1 font-medium">
+            {address}
+          </Lead>
+          <Lead className="order-8 col-span-2 font-medium">
+            {participantCount}
+          </Lead>
         </div>
       </div>
-      <div className="flex flex-col gap-2">
-        <Button variant="outline" className="px-2 py-1 text-sm" asChild>
+      <div className="flex flex-col gap-4 p-6 xl:pr-6">
+        <Button
+          variant="outline"
+          className="border-primary px-2 py-1 text-sm"
+          asChild
+        >
           <Link href={`/member-center/manage-event/${id}/${name}`}>詳情</Link>
         </Button>
-
-        <Button variant="outline" disabled className="px-2 py-1 text-sm">
+        <Button
+          variant="outline"
+          disabled
+          className="border-primary px-2 py-1 text-sm"
+        >
           取消活動
         </Button>
       </div>

--- a/src/app/member-center/manage-event/utils/QRCodeScannerDialogButton.tsx
+++ b/src/app/member-center/manage-event/utils/QRCodeScannerDialogButton.tsx
@@ -51,7 +51,7 @@ const QRCodeScannerDialogButton = ({
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button variant="default" className="max-w-fit xl:w-full">
+        <Button variant="default" className="xl:w-full xl:max-w-fit">
           {name}
         </Button>
       </DialogTrigger>

--- a/src/components/user/UserProfileForm/UserProfileForm.tsx
+++ b/src/components/user/UserProfileForm/UserProfileForm.tsx
@@ -89,7 +89,7 @@ const UserProfileForm: React.FC<UserProfileFormProps> = ({ defaultData }) => {
           defaultValue={['item-1', 'item-2']}
         >
           <AccordionItem value="item-1">
-            <AccordionTrigger className="px-2 text-xl font-bold -tracking-[0.005em]">
+            <AccordionTrigger className="pr-2 text-xl font-bold -tracking-[0.005em] hover:no-underline">
               基本資料
             </AccordionTrigger>
             <AccordionContent>
@@ -252,7 +252,7 @@ const UserProfileForm: React.FC<UserProfileFormProps> = ({ defaultData }) => {
             </AccordionContent>
           </AccordionItem>
           <AccordionItem value="item-2">
-            <AccordionTrigger className="px-2 text-xl font-bold -tracking-[0.005em]">
+            <AccordionTrigger className="pr-2 text-xl font-bold -tracking-[0.005em] hover:no-underline">
               聯絡資料
             </AccordionTrigger>
             <AccordionContent>


### PR DESCRIPTION
## Description
修改會員中心的樣式，以符合整體設計風格。

## DEMO
![image](https://github.com/ChillKa/chillka-frontend/assets/70134552/2a3b953f-adb8-43f5-a9d3-2647ce67dd68)
![image](https://github.com/ChillKa/chillka-frontend/assets/70134552/22d52228-e777-4310-996a-c61a3c6a0dc2)

## Note
1. 以結構不動為原則進行修改，大部分調整顏色與字體大小以及卡片大小。
2. 管理個別活動頁的 table 在 mobile 版本（420px 以下）會有 overflow-x，暫時沒有找到解法（pending）。

## Reference
[Table not responsive and action menu not working](https://github.com/shadcn-ui/ui/issues/1271)
[Data Table Mobile responsive issue](https://github.com/shadcn-ui/ui/issues/763#issuecomment-1611723056)