### PR TITLE
fix: 🐛 activity-to-activity-creation-navigation-map-error

### DIFF
--- a/src/components/GoogleMaps/ActivityLocationMarker/ActivityLocationMarker.tsx
+++ b/src/components/GoogleMaps/ActivityLocationMarker/ActivityLocationMarker.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Loader } from '@googlemaps/js-api-loader';
+import { Libraries, Loader } from '@googlemaps/js-api-loader';
 import cn from '@lib/utils';
 import { useEffect, useRef } from 'react';
 
@@ -9,6 +9,8 @@ type ActivityLocationMarkerProps = {
   lat: number;
   lng: number;
 };
+
+const libraries: Libraries = ['places'];
 
 const ActivityLocationMarker = ({
   className,
@@ -29,6 +31,7 @@ const ActivityLocationMarker = ({
       const loader = new Loader({
         apiKey: process.env.NEXT_PUBLIC_GOOGLE_MAP_API_KEY as string,
         version: 'weekly',
+        libraries,
       });
 
       const { Map } = (await loader.importLibrary(


### PR DESCRIPTION
## Description

- When users navigate from the `activity/[id]` page to the `activity/new` path, both pages load Google Maps simultaneously, which causes errors.

- error occurs films

https://github.com/ChillKa/chillka-frontend/assets/70035368/bb4633ad-27e9-4299-ba98-28c5ff05dc43

## Fix Method
- add libraries into map loader
- ref: https://stackoverflow.com/questions/59721795/react-js-google-map-react-google-maps-api-add-standalonesearchbox

## Test

https://github.com/ChillKa/chillka-frontend/assets/70035368/897dc8f5-30eb-42e3-9d3a-34bb990920ec


