### PR TITLE
feat: 🎸 add padding to EventCard and SearchResultEventCard

### DIFF
--- a/src/components/EventCard/EventCard.tsx
+++ b/src/components/EventCard/EventCard.tsx
@@ -83,7 +83,7 @@ const EventCard = forwardRef<HTMLDivElement, EventCardProps>(
           ref={ref}
           id="event-card"
           className={cn(
-            'flex h-[35.25rem] w-full flex-col gap-8 text-primary',
+            'flex h-[35.25rem] w-full flex-col gap-8 pb-4 text-primary',
             'xl:max-w-[26rem]',
             'duration-1000 ease-in-out',
             'transition-shadow hover:shadow-[0px_5px_15px_0px_rgba(0,0,0,0.05)]',
@@ -98,14 +98,14 @@ const EventCard = forwardRef<HTMLDivElement, EventCardProps>(
             revalidate={revalidate}
           />
 
-          <div className="flex h-[5.5rem] w-full flex-col gap-4">
+          <div className="flex h-[5.5rem] w-full flex-col gap-4 px-4">
             <H3 className="truncate">{title}</H3>
             <p className="line-clamp-2 overflow-hidden text-ellipsis text-sm">
               {summary}
             </p>
           </div>
 
-          <div className="flex h-[9rem] flex-col justify-between gap-4">
+          <div className="flex h-[9rem] flex-col justify-between gap-4 px-4">
             <EventCardInfoSection
               startTime={format(new Date(startTime), 'MM.dd （EEEEE） ', {
                 locale: zhTW,
@@ -119,7 +119,7 @@ const EventCard = forwardRef<HTMLDivElement, EventCardProps>(
             />
           </div>
 
-          <div className="flex h-7 items-center justify-start gap-2">
+          <div className="flex h-7 items-center justify-start gap-2 px-4">
             {nearestTicket && nearestTicket.price > 0 ? (
               <>
                 <span className="text-lg font-bold">

--- a/src/components/EventCard/SearchResultEventCard.tsx
+++ b/src/components/EventCard/SearchResultEventCard.tsx
@@ -108,7 +108,7 @@ const SearchResultEventCard = ({
           activityId={link}
         />
 
-        <div className="flex h-full w-[32.875rem] flex-col items-stretch justify-start gap-4">
+        <div className="flex h-full w-[32.875rem] flex-col items-stretch justify-start gap-4 p-4">
           <div id="activity-header" className="flex flex-col gap-2">
             <H3>{title}</H3>
             <p className="truncate text-sm font-normal">{summary}</p>

--- a/src/components/search/SearchContentSection.tsx
+++ b/src/components/search/SearchContentSection.tsx
@@ -64,7 +64,10 @@ const SearchContentSection = ({
   const [centerId, setCenterId] = useState(results[0]?._id ?? '-1');
 
   return (
-    <section id="result" className="flex w-full grow flex-row gap-6">
+    <section
+      id="result"
+      className="flex w-full grow flex-row gap-6 px-3 xl:px-0"
+    >
       {currentShow === 'results' && (
         <div
           id="result-list"
@@ -107,7 +110,7 @@ const SearchContentSection = ({
                 ticketPrices={activity?.ticketPrice ?? []}
                 isContinuous={activity.isContinuous}
                 discount={0}
-                className="gap-4"
+                className="h-auto gap-4"
                 onVisibleTrigger={() => {
                   setCenterId(activity._id);
                 }}


### PR DESCRIPTION
## Description
1. 原設計稿活動卡片的 content 區塊 style 並無 `padding`，因應教練建議在首頁及搜尋頁的活動卡片增加 `padding`。
![image](https://github.com/ChillKa/chillka-frontend/assets/70134552/a4a6cf2a-a87e-49c1-9545-423f29c060de)
![image](https://github.com/ChillKa/chillka-frontend/assets/70134552/67a07844-7f59-4ee0-a08c-ffab8969d745)

2. 修正搜尋頁面 mobile 版本的 `padding-x` 與卡片高度。
![image](https://github.com/ChillKa/chillka-frontend/assets/70134552/4e521f0a-b608-44aa-a1d7-4ef211c5d8c9)
