### PR TITLE
fix: 🐛 prevent activity creator from submitting questions

### DIFF
--- a/src/components/ActivityPage/QuestionsSetcion/QuestionsSetcion.tsx
+++ b/src/components/ActivityPage/QuestionsSetcion/QuestionsSetcion.tsx
@@ -3,6 +3,7 @@
 import { fetchActivity } from '@action/activity';
 import Question from '@components/ActivityPage/QuestionsSetcion/Question';
 import UserComment from '@components/ActivityPage/QuestionsSetcion/UserComment';
+import { P } from '@components/ui/typography';
 import cn from '@lib/utils';
 import { useCallback, useEffect, useState } from 'react';
 import { IAcitivityResponse } from 'src/types/activity';
@@ -36,6 +37,7 @@ const QuestionsSetcion = ({
       <div className="mb-4 text-2xl font-bold -tracking-[0.006em] xl:mb-6 xl:text-3xl xl:-tracking-[0.0075em]">
         Q&A
       </div>
+      {data?.questions.length === 0 && <P className="mb-12">目前尚未有提問</P>}
       {data?.questions &&
         data.questions.map((question, index) => {
           const isLast = index === data.questions.length - 1;
@@ -51,6 +53,7 @@ const QuestionsSetcion = ({
           );
         })}
       <UserComment
+        data={data!}
         activityId={activityId!}
         getActivity={getActivity}
         previewMode={previewMode}

--- a/src/components/ActivityPage/QuestionsSetcion/UserComment/UserComment.tsx
+++ b/src/components/ActivityPage/QuestionsSetcion/UserComment/UserComment.tsx
@@ -4,24 +4,27 @@ import Comment from '@components/ActivityPage/QuestionsSetcion/Comment';
 import { Avatar, AvatarFallback, AvatarImage } from '@components/ui/avatar';
 import { P } from '@components/ui/typography';
 import { useAuthContext } from '@store/AuthProvider/AuthProvider';
+import { IAcitivityResponse } from 'src/types/activity';
 
 type UserCommentProps = {
   activityId: string;
+  data: IAcitivityResponse;
   getActivity: (id: string) => Promise<void>;
   previewMode: boolean;
 };
 
 const UserComment = ({
+  data,
   activityId,
   getActivity,
   previewMode,
 }: UserCommentProps) => {
-  const { isLoggedin, userName, userAvatar } = useAuthContext();
+  const { isLoggedin, userName, userAvatar, auth } = useAuthContext();
   const firstLetter = userName.charAt(0);
-
+  const isActvityCreator = data?.activity.creatorId === auth?._id;
   return (
     <div className="mt-4 xl:mt-6">
-      {isLoggedin && !previewMode ? (
+      {isLoggedin && !previewMode && !isActvityCreator && (
         <div className="flex gap-4 xl:gap-6">
           <Avatar className="h-12 w-12 rounded-full">
             <AvatarImage
@@ -41,9 +44,8 @@ const UserComment = ({
             getActivity={getActivity}
           />
         </div>
-      ) : (
-        <P>需登入才能提問</P>
       )}
+      {!isLoggedin && <P>需登入才能提問</P>}
     </div>
   );
 };


### PR DESCRIPTION
## Description
1. 活動創辦者不可自行提問，原本提問送出會報錯，改成若為創辦者就隱藏提問區塊。
2. Q&A 若無提問，則顯示「目前尚未有提問」。

## Test
1. 為主辦方
![image](https://github.com/ChillKa/chillka-frontend/assets/70134552/89e1dbab-fa17-4594-a4eb-de67b7d64160)
2. 非主辦方
![image](https://github.com/ChillKa/chillka-frontend/assets/70134552/e0a9f178-eaa9-4ef0-9075-07d707b4575e)
3. 為主辦方尚未有提問
![image](https://github.com/ChillKa/chillka-frontend/assets/70134552/708ce057-18f9-4b83-87d6-da7afca9a38a)
4. 為主辦方尚未有提問
![image](https://github.com/ChillKa/chillka-frontend/assets/70134552/0ae505a3-528c-491b-8752-7c4e2dfab8ca)
