### PR TITLE
fix: 🐛 update links for recommended activities in search

### DIFF
--- a/src/action/activity.ts
+++ b/src/action/activity.ts
@@ -128,7 +128,7 @@ export async function getRecommendActivitiesByKeyword(keyword: string) {
       })),
       pictures: activitiesResult.data.map((activity: Activity) => ({
         thumbnail: activity.thumbnail,
-        url: activity.link,
+        id: activity._id,
         description: activity.name,
       })),
     };

--- a/src/components/SearchBar/fields/ActivityField.tsx
+++ b/src/components/SearchBar/fields/ActivityField.tsx
@@ -30,7 +30,7 @@ export type ActivityKeyword = {
 
 export type ActivityPicture = {
   thumbnail: string;
-  url: string;
+  id: string;
   description: string;
 };
 
@@ -139,7 +139,7 @@ const ActivityField = ({
                     key={num}
                     thumbnail={item.thumbnail}
                     description={item.description}
-                    link={item.url}
+                    id={item.id}
                   />
                 );
               })}
@@ -214,7 +214,7 @@ export const ActivityMobileField = ({
                   key={num}
                   thumbnail={item.thumbnail}
                   description={item.description}
-                  link={item.url}
+                  id={item.id}
                 />
               );
             })}

--- a/src/components/SearchBar/fields/ActivityResultThumbnail.tsx
+++ b/src/components/SearchBar/fields/ActivityResultThumbnail.tsx
@@ -15,19 +15,19 @@ export const SkeletonActivityResultThumbnail = () => {
 };
 
 type ActivityResultThumbnailProps = {
-  link?: string;
+  id?: string;
   thumbnail?: string;
   description: string;
 };
 const ActivityResultThumbnail = ({
-  link,
+  id,
   thumbnail,
   description,
 }: ActivityResultThumbnailProps) => {
   const [imageSrc, setImageSrc] = useState(thumbnail ?? '/default.webp');
 
   return (
-    <Link href={link ?? '/search'}>
+    <Link href={`/activity/${id}` ?? '/search'}>
       <div className="min-w-fit space-y-2">
         <Image
           src={imageSrc}


### PR DESCRIPTION
## Description
將「推薦活動」取得的資料 `id` 替換原先的 `link`，導向至該活動頁。
![image](https://github.com/ChillKa/chillka-frontend/assets/70134552/486318aa-3789-481a-837d-622ed976305f)
