### PR TITLE
feat: 🎸 revalidate data when favorited status changes

### DIFF
--- a/src/action/activity.ts
+++ b/src/action/activity.ts
@@ -3,7 +3,7 @@
 import { SearchParams } from '@components/SearchBar/fields/utils';
 import { userCommentSchema } from '@lib/definitions';
 import { createDebounce } from '@lib/utils';
-import { revalidatePath } from 'next/cache';
+import { revalidatePath, revalidateTag } from 'next/cache';
 import { z } from 'zod';
 import { IAcitivityResponse, IActivity } from '../types/activity';
 import { fetchAPI, getJwtPayload, validateWithSchema } from './utils';
@@ -272,7 +272,8 @@ export async function toggleFavoriteActivity(
       };
     }
 
-    if (revalidate) revalidatePath('/member-center/favorite-event', 'layout');
+    if (revalidate) revalidatePath('/member-center/favorite-event');
+    revalidateTag('favoritedActivities');
 
     return {
       status: 'success',
@@ -297,6 +298,7 @@ export async function getFavoriteActivities(): Promise<FavoriteActivitiesResult>
     api: `/auth/saved-activities`,
     method: 'GET',
     shouldAuth: true,
+    option: { next: { tags: ['favoritedActivities'] } },
   });
 
   if (!response.ok) {

--- a/src/action/activity.ts
+++ b/src/action/activity.ts
@@ -3,7 +3,7 @@
 import { SearchParams } from '@components/SearchBar/fields/utils';
 import { userCommentSchema } from '@lib/definitions';
 import { createDebounce } from '@lib/utils';
-import { revalidatePath, revalidateTag } from 'next/cache';
+import { revalidateTag } from 'next/cache';
 import { z } from 'zod';
 import { IAcitivityResponse, IActivity } from '../types/activity';
 import { fetchAPI, getJwtPayload, validateWithSchema } from './utils';
@@ -253,8 +253,7 @@ export type ActivityState =
     };
 
 export async function toggleFavoriteActivity(
-  activityId: string,
-  revalidate?: boolean
+  activityId: string
 ): Promise<ActivityState> {
   try {
     const response = await fetchAPI({
@@ -272,7 +271,6 @@ export async function toggleFavoriteActivity(
       };
     }
 
-    if (revalidate) revalidatePath('/member-center/favorite-event');
     revalidateTag('favoritedActivities');
 
     return {

--- a/src/app/member-center/favorite-event/page.tsx
+++ b/src/app/member-center/favorite-event/page.tsx
@@ -38,7 +38,6 @@ const FavoriteEvent = async () => {
               organizer={activity.organizer.name}
               ticketPrices={activity.tickets}
               isCollected
-              revalidate
             />
           ))
         )}

--- a/src/components/EventCard/EventCard-utils.tsx
+++ b/src/components/EventCard/EventCard-utils.tsx
@@ -59,7 +59,6 @@ type EventCardCoverSectionProps = {
   activityId: string;
   hoverEffect?: boolean;
   className?: string;
-  revalidate?: boolean;
 };
 export const EventCardCoverSection = ({
   src,
@@ -68,7 +67,6 @@ export const EventCardCoverSection = ({
   activityId,
   className,
   hoverEffect = true,
-  revalidate,
 }: EventCardCoverSectionProps) => {
   const [collected, setCollected] = useState(initialCollected);
   const [isPending, startTransition] = useTransition();
@@ -94,7 +92,7 @@ export const EventCardCoverSection = ({
 
       startTransition(async () => {
         try {
-          const response = await toggleFavoriteActivity(activityId, revalidate);
+          const response = await toggleFavoriteActivity(activityId);
           if (response?.message) {
             toast({
               title: response.message,
@@ -114,7 +112,7 @@ export const EventCardCoverSection = ({
         }
       });
     },
-    [activityId, revalidate]
+    [activityId]
   );
 
   const renderStatusIcon = () => {

--- a/src/components/EventCard/EventCard.tsx
+++ b/src/components/EventCard/EventCard.tsx
@@ -31,7 +31,6 @@ type EventCardProps = {
   link?: string;
   discount?: number;
   className?: string;
-  revalidate?: boolean;
 };
 
 const EventCard = forwardRef<HTMLDivElement, EventCardProps>(
@@ -51,7 +50,6 @@ const EventCard = forwardRef<HTMLDivElement, EventCardProps>(
       link = '',
       discount = 0,
       className,
-      revalidate,
     },
     ref
   ) => {
@@ -93,7 +91,6 @@ const EventCard = forwardRef<HTMLDivElement, EventCardProps>(
             src={cover}
             collected={isCollected}
             activityId={link}
-            revalidate={revalidate}
           />
 
           <div className="flex h-[5.5rem] w-full flex-col gap-4 px-4">


### PR DESCRIPTION
## Description
1. 當首頁活動卡片收藏狀態更新時，進入會員中心的「收藏活動」也會重新取得資料（原本有 cache 會顯示舊的，須重新整理才會再更新）。
2. 在會員中心的「收藏活動」更改活動收藏狀態，首頁的活動卡片也會更新。